### PR TITLE
DeleteNote accepts a note title as an argument

### DIFF
--- a/plugin/notes.vim
+++ b/plugin/notes.vim
@@ -47,7 +47,7 @@ endif
 " User commands to create, delete and search notes.
 command! -bar -bang -nargs=? -complete=customlist,xolox#notes#cmd_complete Note call xolox#notes#edit(<q-bang>, <q-args>)
 command! -bar -bang -range NoteFromSelectedText call xolox#notes#from_selection(<q-bang>)
-command! -bar -bang DeleteNote call xolox#notes#delete(<q-bang>)
+command! -bar -bang -nargs=? -complete=customlist,xolox#notes#cmd_complete DeleteNote call xolox#notes#delete(<q-bang>, <q-args>)
 command! -bang -nargs=? SearchNotes call xolox#notes#search(<q-bang>, <q-args>)
 command! -bar -bang RelatedNotes call xolox#notes#related(<q-bang>)
 command! -bar -bang -nargs=? RecentNotes call xolox#notes#recent(<q-bang>, <q-args>)


### PR DESCRIPTION
This way you can delete notes without having to first open them.

Also allows completion of note titles.

Also prevent deleting and clearing the current (file, buffer) pair if
its not a `vim-note`

xolox#notes#exists : returns true if a given note exists
