### PR TITLE
Add an optional checkbox writing aid

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The notes.vim plug-in for the [Vim text editor] [vim] makes it easy to manage yo
    * A [Python 2] [python] script is included that accelerates keyword searches using a keyword index
    * The `:RecentNotes` command lists your notes by modification date, starting with the most recently edited note
  * **Navigating between notes:** The included syntax script highlights note names as hyper links and the file type plug-in redefines [gf] [gf] to jump between notes (the [Control-w f] [ctrlwf] mapping to jump to a note in a split window and the [Control-w gf] [ctrlwgf] mapping to jump to a note in a new tab page also work)
- * **Writing aids:** The included file type plug-in contains mappings for automatic curly quotes, arrows and list bullets and supports completion of note titles using Control-X Control-U and completion of tags using Control-X Control-O
+ * **Writing aids:** The included file type plug-in contains mappings for automatic curly quotes, arrows, list bullets and check boxes and supports completion of note titles using Control-X Control-U and completion of tags using Control-X Control-O
  * **Embedded file types:** The included syntax script supports embedded highlighting using blocks marked with `{{{type … }}}` which allows you to embed highlighted code and configuration snippets in your notes
 
 Here's a screen shot of the syntax mode using the [slate] [slate] color scheme:
@@ -68,6 +68,16 @@ A list of characters used as list bullets. When you're using a Unicode encoding 
 When you change the nesting level (indentation) of a line containing a bullet point using one of the mappings `Tab`, `Shift-Tab`, `Alt-Left` and `Alt-Right` the bullet point will be automatically changed to correspond to the new nesting level.
 
 The first level of list items gets the first bullet point in `g:notes_list_bullets`, the second level gets the second, etc. When you're indenting a list item to a level where the `g:notes_list_bullets` doesn't have enough bullets, the plug-in starts again at the first bullet in the list (in other words the selection of bullets wraps around).
+
+### The `g:notes_checkboxes` option
+
+A list of strings used as check boxes. The first and second elements of this list are used for the unchecked and checked check boxes, respectively.
+
+    :let g:notes_checkboxes = ['×','✓']
+    :let g:notes_checkboxes = ['☐','☑']
+    :let g:notes_checkboxes = ['[ ]', '[x]']
+
+To disable check boxes all together, set `g:notes_checkboxes` to `[]`.
 
 ### The `g:notes_shadowdir` option
 
@@ -175,6 +185,20 @@ The notes plug-in defines an omni completion function that can be used to comple
 The completion menu is populated from a text file listing all your tags, one on each line. The first time omni completion triggers, an index of tag names is generated and saved to the location set by `g:notes_tagsindex`. After this file is created, it will be updated automatically as you edit notes and add/remove tags.
 
 If for any reason you want to recreate the list of tags you can execute the `:IndexTaggedNotes` command.
+
+### The `:NoteToggleCheckbox` command
+
+If the current line starts with a check box, toggle among its states. Check box characters are set by `g:notes_checkboxes`
+
+### The `:NoteToggleCheckboxTimestamp` command
+
+Similar to `:NoteToggleCheckbox`, but also add a timestamp to checked check boxes. Example:
+
+    [ ] a checkbox item
+    :NoteToggleCheckboxTimestamp
+    [x] (2012-11-10 09:08)  a checkbox item
+    :NoteToggleCheckboxTimestamp
+    [ ] a checkbox item
 
 ## Mappings
 

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -13,10 +13,11 @@ Contents ~
   4. The |g:notes_smart_quotes| option
   5. The |g:notes_ruler_text| option
   6. The |g:notes_list_bullets| option
-  7. The |g:notes_shadowdir| option
-  8. The |g:notes_indexfile| option
-  9. The |g:notes_indexscript| option
-  10. The |g:notes_tagsindex| option
+  7. The |g:notes_checkboxes| option
+  8. The |g:notes_shadowdir| option
+  9. The |g:notes_indexfile| option
+  10. The |g:notes_indexscript| option
+  11. The |g:notes_tagsindex| option
  4. Commands                                                    |notes-commands|
   1. The |:Note| command
   2. The |:NoteFromSelectedText| command
@@ -30,6 +31,9 @@ Contents ~
   8. The |:RecentNotes| command
   9. The |:ShowTaggedNotes| command
   10. The |:IndexTaggedNotes| command
+  11. The |:NoteToggleCheckbox| command
+  12. The |:NoteToggleCheckboxTimestamp| command
+
  5. Mappings                                                    |notes-mappings|
   1. Insert mode mappings                           |notes-insert-mode-mappings|
  6. Customizing the syntax highlighting of notes
@@ -99,10 +103,10 @@ notes in Vim:
    and the Control-w gf (see |CTRL-W_gf|) mapping to jump to a note in a new tab
    page also work)
 
- - Writing aids: The included file type plug-in contains mappings for automatic
-   curly quotes, arrows and list bullets and supports completion of note
-   titles using Control-X Control-U and completion of tags using Control-X
-   Control-O
+ - Writing aids: The included file type plug-in contains mappings for
+   automatic curly quotes, arrows, list bullets and check boxes and supports
+   completion of note titles using Control-X Control-U and completion of tags
+   using Control-X Control-O
 
  - Embedded file types: The included syntax script supports embedded
    highlighting using blocks marked with '{{{type … }}}' which allows you to
@@ -204,6 +208,18 @@ The first level of list items gets the first bullet point in
 indenting a list item to a level where the |g:notes_list_bullets| doesn't have
 enough bullets, the plug-in starts again at the first bullet in the list (in
 other words the selection of bullets wraps around).
+
+-------------------------------------------------------------------------------
+The *g:notes_checkboxes* option
+
+A list of strings used as check boxes. The first and second elements of this
+list are used for the unchecked and checked check boxes, respectively.
+>
+    :let g:notes_checkboxes = ['×','✓']
+    :let g:notes_checkboxes = ['☐','☑']
+    :let g:notes_checkboxes = ['[ ]', '[x]']
+<
+To disable check boxes all together, set |g:notes_checkboxes| to [].
 
 -------------------------------------------------------------------------------
 The *g:notes_shadowdir* option
@@ -392,6 +408,24 @@ add/remove tags.
 If for any reason you want to recreate the list of tags you can execute the
 |:IndexTaggedNotes| command.
 
+-------------------------------------------------------------------------------
+The *:NoteToggleCheckbox* command
+
+If the current line starts with a check box, toggle among its states. Check
+box characters are set by |g:notes_checkboxes|
+
+-------------------------------------------------------------------------------
+The *:NoteToggleCheckboxTimestamp* command
+
+Similar to |:NoteToggleCheckbox|, but also add a timestamp to checked check
+boxes. Example:
+>
+    [ ] a checkbox item
+    :NoteToggleCheckboxTimestamp
+    [x] (2012-11-10 09:08)  a checkbox item
+    :NoteToggleCheckboxTimestamp
+    [ ] a checkbox item
+<
 ===============================================================================
                                                                 *notes-mappings*
 Mappings ~
@@ -433,6 +467,7 @@ Insert mode mappings ~
 
  - '\tn' executes |:TabNoteFromSelectedText|
 
+
 ===============================================================================
 Customizing the syntax highlighting of notes ~
 
@@ -460,6 +495,12 @@ are the names of the syntax items defined by the notes syntax mode:
  - 'notesDoubleQuoted' - double quoted strings
 
  - 'notesSingleQuoted' - single quoted strings
+
+ - 'notesCheckbox' - unchecked check boxes
+
+ - 'notesCheckedbox' - checked check boxes
+
+ - 'notesCheckboxTimestamp' - the (optional) timestamp following a checked check box
 
  - 'notesItalic' - strings between two '_' characters
 

--- a/ftplugin/notes.vim
+++ b/ftplugin/notes.vim
@@ -87,6 +87,11 @@ if g:notes_smart_quotes
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> +"'
 endif
 
+if len(g:notes_checkboxes)
+    imap <buffer> <expr> [] xolox#notes#insert_checkbox('[]')
+    let b:undo_ftplugin .= ' | execute "iunmap <buffer> []"'
+endif
+
 " Format three asterisks as a horizontal ruler. {{{1
 inoremap <buffer> *** <C-o>:call xolox#notes#insert_ruler()<CR>
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> ***"'
@@ -111,8 +116,8 @@ smap <buffer> <silent> <A-Left> <C-o>:<C-u>call xolox#notes#indent_list(-1, line
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> <A-Left>"'
 let b:undo_ftplugin .= ' | execute "sunmap <buffer> <A-Left>"'
 
-" Automatically remove empty list items on Enter. {{{1
-inoremap <buffer> <silent> <expr> <CR> xolox#notes#cleanup_list()
+" Automatically remove empty list and checkbox items on Enter. {{{1
+inoremap <buffer> <silent> <expr> <CR> xolox#notes#cleanup_redundant()
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> <CR>"'
 
 " Shortcuts to create new notes from the selected text. {{{1

--- a/plugin/notes.vim
+++ b/plugin/notes.vim
@@ -23,6 +23,10 @@ command! -bar -bang -nargs=? RecentNotes call xolox#notes#recent(<q-bang>, <q-ar
 command! -bar -count=1 ShowTaggedNotes call xolox#notes#tags#show_tags(<count>)
 command! -bar IndexTaggedNotes call xolox#notes#tags#create_index()
 
+" Checkbox toggling commands
+command! -bar NoteToggleCheckbox call xolox#notes#toggle_checkbox()
+command! -bar NoteToggleCheckboxTimestamp call xolox#notes#toggle_checkbox_timestamp()
+
 " TODO Generalize this so we have one command + modifiers (like :tab)?
 command! -bar -bang -range NoteFromSelectedText call xolox#notes#from_selection(<q-bang>, 'edit')
 command! -bar -bang -range SplitNoteFromSelectedText call xolox#notes#from_selection(<q-bang>, 'vsplit')

--- a/syntax/notes.vim
+++ b/syntax/notes.vim
@@ -37,6 +37,15 @@ highlight def link notesListBullet Comment
 syntax match notesListNumber /^\s*\zs\d\+[[:punct:]]\?\ze\s/
 highlight def link notesListNumber Comment
 
+" Highlight checkboxes. {{{2
+execute 'syntax match notesCheckbox /'   . escape(xolox#notes#leading_checkbox_pattern(), '/') . '/' 
+execute 'syntax match notesCheckedbox /' . escape(xolox#notes#leading_checkedbox_pattern(), '/') . '/ nextgroup=notesCheckboxTimestamp'
+syntax match notesCheckboxTimestamp / (\d\d\d\d-\d\d-\d\d\s\d\d:\d\d\(:\d\d\)\?)/ contained
+
+highlight def link notesCheckbox Special
+highlight def link notesCheckedbox Question
+highlight def link notesCheckboxTimestamp Comment
+
 " Highlight quoted fragments. {{{2
 if xolox#notes#unicode_enabled()
   syntax match notesDoubleQuoted /“.\{-}”/


### PR DESCRIPTION
First of all, thank you for vim-notes. It is of great use to me.

This pull requests adds an optional (disable it with by setting `g:notes_checkboxes` to `[]`) check box writing aid and two toggling commands. It's a bit rough around the edges, but it mostly works.

![Check boxes](http://i.imgur.com/hTuzh.png)
