### PR TITLE
Please use *noremap flavor commands for all mappings

### DIFF
--- a/ftplugin/notes.vim
+++ b/ftplugin/notes.vim
@@ -57,31 +57,31 @@ set completeopt+=longest
 
 " Change double-dash to em-dash as it is typed. {{{1
 if g:notes_smart_quotes && xolox#notes#unicode_enabled()
-  imap <buffer> -- —
+  inoremap <buffer> -- —
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> --"'
 endif
 
 " Change plain quotes to curly quotes as they're typed. {{{1
 if g:notes_smart_quotes
-  imap <buffer> <expr> ' xolox#notes#insert_quote(1)
-  imap <buffer> <expr> " xolox#notes#insert_quote(2)
+  inoremap <buffer> <expr> ' xolox#notes#insert_quote(1)
+  inoremap <buffer> <expr> " xolox#notes#insert_quote(2)
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> ''"'
   let b:undo_ftplugin .= ' | execute ''iunmap <buffer> "'''
 endif
 
 " Change ASCII style arrows to Unicode arrows. {{{1
 if g:notes_smart_quotes && xolox#notes#unicode_enabled()
-  imap <buffer> -> →
-  imap <buffer> <- ←
+  inoremap <buffer> -> →
+  inoremap <buffer> <- ←
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> ->"'
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> <-"'
 endif
 
 " Convert ASCII list bullets to Unicode bullets. {{{1
 if g:notes_smart_quotes
-  imap <buffer> <expr> * xolox#notes#insert_bullet('*')
-  imap <buffer> <expr> - xolox#notes#insert_bullet('-')
-  imap <buffer> <expr> + xolox#notes#insert_bullet('+')
+  inoremap <buffer> <expr> * xolox#notes#insert_bullet('*')
+  inoremap <buffer> <expr> - xolox#notes#insert_bullet('-')
+  inoremap <buffer> <expr> + xolox#notes#insert_bullet('+')
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> *"'
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> -"'
   let b:undo_ftplugin .= ' | execute "iunmap <buffer> +"'
@@ -92,22 +92,22 @@ inoremap <buffer> *** <C-o>:call xolox#notes#insert_ruler()<CR>
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> ***"'
 
 " Indent list items using <Tab> and <Shift-Tab>. {{{1
-imap <buffer> <silent> <Tab> <C-o>:call xolox#notes#indent_list(1, line('.'), line('.'))<CR>
-smap <buffer> <silent> <Tab> <C-o>:<C-u>call xolox#notes#indent_list(1, line("'<"), line("'>"))<CR><C-o>gv
+inoremap <buffer> <silent> <Tab> <C-o>:call xolox#notes#indent_list(1, line('.'), line('.'))<CR>
+snoremap <buffer> <silent> <Tab> <C-o>:<C-u>call xolox#notes#indent_list(1, line("'<"), line("'>"))<CR><C-o>gv
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> <Tab>"'
 let b:undo_ftplugin .= ' | execute "sunmap <buffer> <Tab>"'
-imap <buffer> <silent> <S-Tab> <C-o>:call xolox#notes#indent_list(-1, line('.'), line('.'))<CR>
-smap <buffer> <silent> <S-Tab> <C-o>:<C-u>call xolox#notes#indent_list(-1, line("'<"), line("'>"))<CR><C-o>gv
+inoremap <buffer> <silent> <S-Tab> <C-o>:call xolox#notes#indent_list(-1, line('.'), line('.'))<CR>
+snoremap <buffer> <silent> <S-Tab> <C-o>:<C-u>call xolox#notes#indent_list(-1, line("'<"), line("'>"))<CR><C-o>gv
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> <S-Tab>"'
 let b:undo_ftplugin .= ' | execute "sunmap <buffer> <S-Tab>"'
 
 " Indent list items using <Alt-Left> and <Alt-Right>. {{{1
-imap <buffer> <silent> <A-Right> <C-o>:call xolox#notes#indent_list(1, line('.'), line('.'))<CR>
-smap <buffer> <silent> <A-Right> <C-o>:<C-u>call xolox#notes#indent_list(1, line("'<"), line("'>"))<CR><C-o>gv
+inoremap <buffer> <silent> <A-Right> <C-o>:call xolox#notes#indent_list(1, line('.'), line('.'))<CR>
+snoremap <buffer> <silent> <A-Right> <C-o>:<C-u>call xolox#notes#indent_list(1, line("'<"), line("'>"))<CR><C-o>gv
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> <A-Right>"'
 let b:undo_ftplugin .= ' | execute "sunmap <buffer> <A-Right>"'
-imap <buffer> <silent> <A-Left> <C-o>:call xolox#notes#indent_list(-1, line('.'), line('.'))<CR>
-smap <buffer> <silent> <A-Left> <C-o>:<C-u>call xolox#notes#indent_list(-1, line("'<"), line("'>"))<CR><C-o>gv
+inoremap <buffer> <silent> <A-Left> <C-o>:call xolox#notes#indent_list(-1, line('.'), line('.'))<CR>
+snoremap <buffer> <silent> <A-Left> <C-o>:<C-u>call xolox#notes#indent_list(-1, line("'<"), line("'>"))<CR><C-o>gv
 let b:undo_ftplugin .= ' | execute "iunmap <buffer> <A-Left>"'
 let b:undo_ftplugin .= ' | execute "sunmap <buffer> <A-Left>"'
 
@@ -117,13 +117,13 @@ let b:undo_ftplugin .= ' | execute "iunmap <buffer> <CR>"'
 
 " Shortcuts to create new notes from the selected text. {{{1
 
-vmap <buffer> <silent> <Leader>en :NoteFromSelectedText<CR>
+vnoremap <buffer> <silent> <Leader>en :NoteFromSelectedText<CR>
 let b:undo_ftplugin .= ' | execute "vunmap <buffer> <Leader>en"'
 
-vmap <buffer> <silent> <Leader>sn :SplitNoteFromSelectedText<CR>
+vnoremap <buffer> <silent> <Leader>sn :SplitNoteFromSelectedText<CR>
 let b:undo_ftplugin .= ' | execute "vunmap <buffer> <Leader>sn"'
 
-vmap <buffer> <silent> <Leader>tn :TabNoteFromSelectedText<CR>
+vnoremap <buffer> <silent> <Leader>tn :TabNoteFromSelectedText<CR>
 let b:undo_ftplugin .= ' | execute "vunmap <buffer> <Leader>tn"'
 
 " }}}1


### PR DESCRIPTION
I have a mapping for `<C-o>` in insert mode set to `<C-w>`. So many insert mode mappings don't work because they are setup with imap, instead of inoremap. I changed it everywhere I could find, but you'll know better.

Please feel free to accept this pull request or address this issue in any other way you see fit. All I ask for is to use `[isvn]noremap` instead of `[isvn]map`.
