### PR TITLE
cache_add: always add to cached_titles and cached_pairs

### DIFF
--- a/autoload/xolox/notes.vim
+++ b/autoload/xolox/notes.vim
@@ -895,12 +895,8 @@ function! xolox#notes#cache_add(filename, title) " {{{3
   let filename = xolox#misc#path#absolute(a:filename)
   if index(s:cached_fnames, filename) == -1
     call add(s:cached_fnames, filename)
-    if !empty(s:cached_titles)
-      call add(s:cached_titles, a:title)
-    endif
-    if !empty(s:cached_pairs)
-      let s:cached_pairs[filename] = a:title
-    endif
+    call add(s:cached_titles, a:title)
+    let s:cached_pairs[filename] = a:title
     let s:cache_mtime = localtime()
   endif
 endfunction


### PR DESCRIPTION
The code appears to have been copied / built on the delete function,
where these checks make sense.

It will only be problematic with a fresh installation / empty caches.

Without this `xolox#notes#get_fnames_and_titles` might produce an error
when building cached_pairs.
