### PR TITLE
Only highlight note names within word boundaries.

### DIFF
--- a/autoload/xolox/notes.vim
+++ b/autoload/xolox/notes.vim
@@ -1067,7 +1067,7 @@ function! xolox#notes#highlight_names(force) " {{{3
     if hlexists('notesName')
       syntax clear notesName
     endif
-    execute 'syntax match notesName /\c\%>1l\%(' . escape(join(titles, '\|'), '/') . '\)/'
+    execute 'syntax match notesName /\c\%>1l\<\%(' . escape(join(titles, '\|'), '/') . '\)\>/'
     let b:notes_names_last_highlighted = localtime()
     call xolox#misc#timer#stop("notes.vim %s: Highlighted note names in %s.", g:xolox#notes#version, starttime)
   endif


### PR DESCRIPTION
I have a few note names which are very short and simple (things like 'pa'). As a result, I get a lot of improper highlighting in another notes. Any word containing 'pa' will become partially underlined.

I've tweaked the regex slightly to only highlight note names within word boundaries. If a note name is surrounded by any word boundary, it is highlighted. If it is embedded within other letters or numbers, it is not highlighted.

Perhaps a personal preference thing, so no worries if you opt to reject this.

Before:

![before](https://cloud.githubusercontent.com/assets/218431/3282806/4bc937b2-f4fe-11e3-9725-75e61304a858.png)

After:

![after](https://cloud.githubusercontent.com/assets/218431/3282808/50f059b4-f4fe-11e3-8b81-c8d6ea01f721.png)
