### PR TITLE
Fix code hightlighting (Remove additional space)

### DIFF
--- a/autoload/xolox/notes.vim
+++ b/autoload/xolox/notes.vim
@@ -1171,7 +1171,7 @@ function! xolox#notes#highlight_sources(force) " {{{3
     for ft in keys(filetypes)
       let group = 'notesSnippet' . toupper(ft)
       let include = s:syntax_include(ft)
-      let command = 'syntax region %s matchgroup=%s start="{{{%s" matchgroup=%s end="}}}" keepend contains=%s%s'
+      let command = 'syntax region %s matchgroup=%s start="{{{%s " matchgroup=%s end="}}}" keepend contains=%s%s'
       execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') ? ' concealends' : '')
     endfor
     if &vbs >= 1


### PR DESCRIPTION
There was a additional space when using code highlight within line?
