### PR TITLE
Remove noautocmd when opening a new note

### DIFF
--- a/autoload/xolox/notes.vim
+++ b/autoload/xolox/notes.vim
@@ -165,7 +165,7 @@ function! xolox#notes#edit(bang, title) abort " {{{1
   endif
   " At this point we're dealing with a new note.
   let fname = xolox#notes#title_to_fname(title)
-  noautocmd execute 'edit' . a:bang fnameescape(fname)
+  execute 'edit' . a:bang fnameescape(fname)
   if line('$') == 1 && getline(1) == ''
     execute 'silent read' fnameescape(g:notes_new_note_template)
     1delete

--- a/plugin/notes.vim
+++ b/plugin/notes.vim
@@ -66,7 +66,7 @@ augroup PluginNotes
 augroup END
 
 augroup filetypedetect
-  let s:template = 'au BufNewFile,BufRead %s if &bt == "" | setl ft=notes | end'
+  let s:template = 'au BufRead %s if &bt == "" | setl ft=notes | end'
   for s:directory in xolox#notes#find_directories(0)
     execute printf(s:template, xolox#notes#autocmd_pattern(s:directory, 1))
   endfor


### PR DESCRIPTION
1) Because of noautocmd other plugins like minibufexpl fails because
they depend on events fired during ":edit" call.
2) Without noautocmd we get the annoying message saying "Changed note
title to match filename".  To remove that I removed BufNewFile event
in the filetypedetect augroup. This will only cause problem when you
start a new note using ":edit path_to_new_note". I feel no one
would be doing that as it is much easier to use ":Note title" or ":edit
note:title" to create a new note named title.
