### PR TITLE
add new markdown style tex math syntax for the notes files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ By default the backticks that mark inline code snippets and the curly quotes tha
 
     This is a sentence with an `inline code` fragment.
 
+### The `g:notes_conceal_math` option
+By default the `$` that marks the inline latex math, and the `$$` or `\[\]` that mark the latex math block are hidden when your version of Vim supports concealing of text. By setting this option to zero you stop vim-notes from hiding this markers.
+
 ### The `g:notes_conceal_italic` option
 
 By default the underscores that mark italic text are hidden when your version of Vim supports concealing of text. By setting this option to zero you stop vim-notes from hiding those underscores. In the following example, the underscores would be visible in the editor when this option is set to zero:
@@ -382,7 +385,7 @@ If you have questions, bug reports, suggestions, etc. the author can be contacte
 
 ## License
 
-This software is licensed under the [MIT license] [mit].  
+This software is licensed under the [MIT license] [mit].
 © 2015 Peter Odding &lt;<peter@peterodding.com>&gt;.
 
 

--- a/doc/notes.txt
+++ b/doc/notes.txt
@@ -26,6 +26,8 @@ Contents ~
   17. The |g:notes_conceal_italic| option
   18. The |g:notes_conceal_bold| option
   19. The |g:notes_conceal_url| option
+  20. The |g:notes_conceal_math| option
+  21. The |g:notes_use_math| option
  4. Commands                                                   |notes-commands|
   1. The |:Note| command
   2. The |:NoteFromSelectedText| command
@@ -376,6 +378,35 @@ stop vim-notes from hiding URL schemes. In the following example, the
 >
   You can find the vim-notes plug-in at https://github.com/xolox/vim-notes.
 <
+
+-------------------------------------------------------------------------------
+The *g:notes_conceal_math* option
+
+By default the dollar sign that mark the tex math region are hidden when you
+virsion of Vim support concealing of text. By setting this option to zero you
+stop vim-notes from hidding those math symbols. In the following example, the
+dollar sign will be visible in editor when this option is set to zero.
+>
+
+  We can insert fomula inline like this $E = mc^2$
+  or we could write the fomula with this
+  $$
+  P(A|B) = \frac{P(B|A)P(A)}{P(B)}
+  $$
+
+-------------------------------------------------------------------------------
+The *g:notes_use_math* option
+
+By default the notes highlights the markdown style math. You could disable the
+highlighting of the math regions by setting this option to zero. The following
+are the math that could be highlighted.
+>
+>
+  inline math $x+y$
+  block math $$x+y$$, \[x+y\]
+  region starts with latex begin end \begin{bmatrix}\end{bmatix}
+
+
 ===============================================================================
                                                                *notes-commands*
 Commands ~
@@ -480,7 +511,7 @@ searching for tags even easier you can create key mappings for the
   " Make the C-] combination search for @tags:
   imap <C-]> <C-o>:SearchNotes<CR>
   nmap <C-]> :SearchNotes<CR>
-  
+
   " Make double mouse click search for @tags. This is actually quite a lot of
   " fun if you don't use the mouse for text selections anyway; you can click
   " between notes as if you're in a web browser:
@@ -653,7 +684,7 @@ To do so you can add lines such as the following to your |vimrc| script:
 >
   " Don't highlight single quoted strings.
   highlight link notesSingleQuoted Normal
-  
+
   " Show double quoted strings in italic font.
   highlight notesDoubleQuoted gui=italic
 <

--- a/syntax/notes.vim
+++ b/syntax/notes.vim
@@ -65,6 +65,23 @@ else
 endif
 syntax cluster notesInline add=notesInlineCode
 highlight def link notesInlineCode Special
+" Highlight the math segments (same as Markdown syntax). {{{2
+if xolox#misc#option#get('notes_use_math', 1)
+  syntax include @tex syntax/tex.vim
+  if has('conceal') && xolox#misc#option#get('notes_conceal_math', 1)
+    syntax region notesInlineMath matchgroup=notesInlineMathMarker start="\\\@<!\$" end="\$" contains=@tex keepend concealends
+    highlight link  notesInlineMathMarker notesHiddenMarker
+    syntax region notesMath start="\\\@<!\$\$" end="\$\$" contains=@tex keepend concealends
+    syntax region notesMath start="\\\@<!\\\[" end="\\\]" contains=@tex keepend concealends
+  else
+    syntax region notesInlineMath start="\\\@<!\$" end="\$" contains=@tex keepend
+    syntax region notesMath start="\\\@<!\$\$" end="\$\$" contains=@tex keepend
+    syntax region notesMath start="\\\@<!\\\[" end="\\\]" contains=@tex keepend
+  endif
+  syntax region notesMath start="\V\\begin{\z(\w\+\)}" end="\V\\end{\z1}" contains=@tex keepend
+  syntax cluster notesInline add=notesInlineMath
+  highlight def link notesInlineMath Special
+endif
 
 " Highlight text emphasized in italic font. {{{2
 if has('conceal') && xolox#misc#option#get('notes_conceal_italic', 1)
@@ -75,7 +92,6 @@ else
 endif
 syntax cluster notesInline add=notesItalic
 highlight notesItalic gui=italic cterm=italic
-
 " Highlight text emphasized in bold font. {{{2
 if has('conceal') && xolox#misc#option#get('notes_conceal_bold', 1)
   syntax region notesBold matchgroup=notesBoldMarker start=/\*\k\@=/ end=/\S\@<=\*/ contains=@Spell concealends


### PR DESCRIPTION
I think it might be a good idea to add markdown style math syntax to notes for those who use math more heavily. 
I created two options `g:notes_conceal_math` options as well as `g:notes_use_math` options.