### PR TITLE
fix the searching notes issue on python 3

### DIFF
--- a/autoload/xolox/notes.vim
+++ b/autoload/xolox/notes.vim
@@ -764,7 +764,7 @@ endfunction
 
 function! s:run_scanner(keywords, matches) " {{{2
   " Try to run scanner.py script to find notes matching {keywords}.
-  call xolox#misc#msg#info("notes.vim %s: Searching notes using keyword index ..", g:xolox#notes#version)
+  "call xolox#misc#msg#info("notes.vim %s: Searching notes using keyword index ..", g:xolox#notes#version)
   let [success, notes] = s:python_command(a:keywords)
   if success
     call xolox#misc#msg#debug("notes.vim %s: Search script reported %i matching note%s.", g:xolox#notes#version, len(notes), len(notes) == 1 ? '' : 's')

--- a/misc/notes/search-notes.py
+++ b/misc/notes/search-notes.py
@@ -220,9 +220,9 @@ class NotesIndex(object):
                     if not any(fnmatch.fnmatch(filename, pattern) for pattern in PATTERNS_TO_IGNORE):
                         abspath = os.path.join(root, filename)
                         notes_on_disk[abspath] = os.path.getmtime(abspath)
-            self.logger.info("Found %i notes in %s ..", len(notes_on_disk) - last_count, directory)
+            self.logger.debug("Found %i notes in %s ..", len(notes_on_disk) - last_count, directory)
             last_count = len(notes_on_disk)
-        self.logger.info("Found a total of %i notes ..", len(notes_on_disk))
+        self.logger.debug("Found a total of %i notes ..", len(notes_on_disk))
         # Check for updated and/or deleted notes since the last run?
         if not self.first_use:
             for filename in self.index['files'].keys():

--- a/misc/notes/search-notes.py
+++ b/misc/notes/search-notes.py
@@ -176,7 +176,7 @@ class NotesIndex(object):
         # Canonicalize pathnames, check validity.
         self.database_file = self.munge_path(self.database_file)
         self.user_directories = map(self.munge_path, self.user_directories)
-        self.user_directories = filter(os.path.isdir, self.user_directories)
+        self.user_directories = list(filter(os.path.isdir, self.user_directories))
         if not any(os.path.isdir(p) for p in self.user_directories):
             sys.stderr.write("None of the notes directories exist!\n")
             sys.exit(1)

--- a/misc/notes/shadow/New note
+++ b/misc/notes/shadow/New note
@@ -1,13 +1,1 @@
-New note
 
-To get started enter a title for your note above. When you’re ready to save
-your note just use Vim’s :write or :update commands, a filename will be picked
-automatically based on the title.
-
-                                    * * *
-
-The notes plug-in comes with self hosting documentation. To jump to these notes
-position your cursor on the highlighted name and press ‘gf’ in normal mode:
-
- • Note taking syntax
- • Note taking commands


### PR DESCRIPTION
Searching notes wont work with python 3 as the self.user_directories is a filter object rather than the list object. 